### PR TITLE
Fixed a linux specific bug.

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,5 @@
-import asyncio
 import logging
 import os
-import signal
 import traceback
 from asyncio import CancelledError
 
@@ -33,11 +31,6 @@ def initiate(states):
         Dock.state_manager_handle = StateManager()
         await Dock.state_manager_handle.put_states(states)
 
-        if not const.IS_WINDOWS:
-            loop = asyncio.get_running_loop()
-            loop.add_signal_handler(signal.SIGINT, Dock.finalizing.set)  # noqa
-            loop.add_signal_handler(signal.SIGTERM, Dock.finalizing.set)  # noqa
-
         cancelled = None
 
         async with Dock.exit_stack:
@@ -63,6 +56,6 @@ def initiate(states):
         exit(0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
     initiate(initial_states())

--- a/src/core/async_runner.py
+++ b/src/core/async_runner.py
@@ -1,18 +1,14 @@
 import asyncio
 from typing import override
 
-from src.avails import const
 from src.core import Dock
 
-if const.IS_WINDOWS:
-    class AnotherRunner(asyncio.Runner):  # noqa # dirty dirty dirty
-        @override
-        def _on_sigint(self, signum, frame, main_task):
-            Dock.finalizing.set()
-            return super()._on_sigint(signum, frame, main_task)
+
+class AnotherRunner(asyncio.Runner):  # noqa # dirty dirty dirty
+    @override
+    def _on_sigint(self, signum, frame, main_task):
+        Dock.finalizing.set()
+        return super()._on_sigint(signum, frame, main_task)
 
 
-    asyncio.Runner = AnotherRunner
-
-else:
-    AnotherRunner = asyncio.Runner
+asyncio.Runner = AnotherRunner

--- a/tests/test.py
+++ b/tests/test.py
@@ -10,7 +10,7 @@ from kademlia import utils
 import _path  # noqa
 import main
 import src
-from src import managers
+from src.core import connectivity
 from src.avails import RemotePeer, const
 from src.avails.connect import UDPProtocol
 from src.configurations import bootup, configure
@@ -41,9 +41,9 @@ def _create_listen_socket_mock(bind_address, _):
 
 def test():
     requests._create_listen_socket = _create_listen_socket_mock
-    const.THIS_IP = '127.0.0.' + sys.argv[1]
+    const.THIS_IP = "127.0.0." + sys.argv[1]
     const.SERVER_IP = const.THIS_IP
-    const.MULTICAST_IP_v4 = '127.0.0.1'
+    const.MULTICAST_IP_v4 = "127.0.0.1"
     const.PORT_NETWORK = 4000
     const.DISCOVER_RETRIES = 1
     set_current_remote_peer_object(
@@ -69,7 +69,9 @@ def get_a_peer() -> RemotePeer | None:
 
 
 def profile_getter():
-    return NamedTuple('MockProfile', (('id', int), ('username', str)))(random.getrandbits(255), getpass.getuser())
+    return NamedTuple("MockProfile", (("id", int), ("username", str)))(
+        random.getrandbits(255), getpass.getuser()
+    )
 
 
 def mock_profile():
@@ -94,14 +96,15 @@ def test_initial_states():
     s7 = State("printing configurations", configure.print_constants)
     s8 = State("initiating requests", requests.initiate)
     s9 = State("initiating comms", connections.initiate_connections, is_blocking=True)
+    s10 = State("connectivity checker", connectivity.initiate)
     return tuple(locals().values())
 
 
 def start_test(other_states):
-    os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+    os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
     main.initiate(test_initial_states() + tuple(other_states))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # print(isinstance(RequestsDispatcher, AbstractDispatcher))
     start_test([])


### PR DESCRIPTION
  removed setting the handler in the current running loop
  the handler is not getting called, but the method used for windows is
  working fine with linux too, so unified the behaviour of sigint
  handling for all operating systems.