### PR TITLE
Closes #48

### DIFF
--- a/src/bootup.py
+++ b/src/bootup.py
@@ -149,6 +149,7 @@ async def init_app(app_runtime: AppRunTime):
     _logger.info("initiating web page servers")
 
     frontend = await pagehandle.init_page_servers(app_config, app_runtime)
+    user_prompts = frontend_web.WebUserPrompts(frontend)
 
     _logger.debug("waiting for profile selection")
     current_profile = await pagehandle.wait_for_profile_selection(frontend, app_runtime)
@@ -174,6 +175,7 @@ async def init_app(app_runtime: AppRunTime):
         peer_service,
         app_runtime,
         app_config,
+        user_prompts,
     )
 
     conn_manager = await init_connection_manager(
@@ -208,8 +210,8 @@ async def init_app(app_runtime: AppRunTime):
         this_remote_peer,
         current_profile,
         conn_manager,
-        frontend_web.ask_user_for_transfer_consent(frontend),
-        frontend_web.WebpageTransferEvents(frontend),
+        user_prompts,
+        app_runtime.app_events,
     )
 
     _logger.info("attaching page handlers")

--- a/src/conduit/app_event_subs.py
+++ b/src/conduit/app_event_subs.py
@@ -1,6 +1,14 @@
 """Functions to subscribe to app events and propagate them to the UI or other perform some routines"""
-from src.conduit.ui_events import PeerPresenceChanged
-from src.core.app_events import AppEventsBus, PeerStatusUpdate
+from src.conduit.ui_events import PeerPresenceChanged, TransferStatusChanged, TransferUpdate
+from src.core.app_events import (
+    AppEventsBus,
+    PeerStatusUpdate,
+    TransferCompleted,
+    TransferConfirmation,
+    TransferIncomplete,
+    TransferProgressUpdated,
+    TransferStarted,
+)
 from .bases import FrontEnd
 from .ui_codec import remote_peer_to_peer_summary
 
@@ -19,3 +27,75 @@ def sub_to_remote_peer_updates(app_event_bus: AppEventsBus, frontend: FrontEnd, 
 
     stat_update_queue = app_event_bus.subscribe(PeerStatusUpdate)
     task_group.create_task(_handler(), name="app-event-handler-peer-status-update")
+
+
+def sub_to_transfer_updates(app_event_bus: AppEventsBus, frontend: FrontEnd, task_group):
+    """Propagate transfer app events to the UI."""
+    transfer_queue = app_event_bus.subscribe(TransferStarted)
+    for event_type in (
+            TransferProgressUpdated,
+            TransferCompleted,
+            TransferIncomplete,
+            TransferConfirmation,
+    ):
+        app_event_bus.subscribe(event_type, queue=transfer_queue)
+
+    converters = {
+        TransferStarted: _started_to_ui_update,
+        TransferProgressUpdated: _progress_to_ui_update,
+        TransferCompleted: _completed_to_ui_update,
+        TransferIncomplete: _incomplete_to_ui_update,
+        TransferConfirmation: _confirmation_to_ui_update,
+    }
+
+    async def _handler():
+        while True:
+            event = await transfer_queue.get()
+            if event is None:
+                return
+            frontend.notify(TransferStatusChanged(converters[type(event)](event)))
+
+    task_group.create_task(_handler(), name="app-event-handler-transfer-updates")
+
+
+def _started_to_ui_update(event: TransferStarted):
+    return TransferUpdate(
+        transfer_id=event.transfer_id,
+        peer_id=event.peer_id,
+    )
+
+
+def _progress_to_ui_update(event: TransferProgressUpdated):
+    return TransferUpdate(
+        transfer_id=event.transfer_id,
+        peer_id=event.peer_id,
+        item_path=event.item_path,
+        progress=event.progress,
+    )
+
+
+def _completed_to_ui_update(event: TransferCompleted):
+    return TransferUpdate(
+        transfer_id=event.transfer_id,
+        peer_id=event.peer_id,
+        completed=True,
+    )
+
+
+def _incomplete_to_ui_update(event: TransferIncomplete):
+    return TransferUpdate(
+        transfer_id=event.transfer_id,
+        peer_id=event.peer_id,
+        item_path=event.item_path,
+        progress=event.progress,
+        cancelled=True,
+        error=event.error,
+    )
+
+
+def _confirmation_to_ui_update(event: TransferConfirmation):
+    return TransferUpdate(
+        transfer_id=event.transfer_id,
+        peer_id=event.peer_id,
+        confirmation=event.confirmed,
+    )

--- a/src/conduit/frontend_web.py
+++ b/src/conduit/frontend_web.py
@@ -1,23 +1,28 @@
 import asyncio
-from typing import runtime_checkable
+from typing import TYPE_CHECKING, runtime_checkable
 
-from conduit import headers
-from conduit.pagehandle import FrontEndMessagesDispatcher, FrontEndWebSockets
-from conduit.ui_events import DecideIncomingTransfer, IncomingTransferDecisionRequested
+from src.conduit.ui_events import (
+    DecideIncomingTransfer,
+    DiscoveryPeerNameRequested,
+    IncomingTransferDecisionRequested,
+    ProvideDiscoveryPeerName,
+)
 from src.avails import use
 from src.avails.exceptions import InvalidPacket
 from src.conduit import ui_codec
 from src.conduit.bases import AnyUIError, AnyUINotification, AnyUIPrompt, AnyUIPromptReply, AnyUIResult, \
     FrontEnd, UIPromptReply
 from src.conduit.ui_codec import DataWeaver
-from transfers.abc import AbstractTransferHandle, TransferEvents
+
+if TYPE_CHECKING:
+    from src.conduit.pagehandle import FrontEndMessagesDispatcher, FrontEndWebSockets
 
 
 @runtime_checkable
 class WebFrontend(FrontEnd):
     """Frontend Abstraction for Web UI"""
 
-    def __init__(self, sender: FrontEndWebSockets, receiver: FrontEndMessagesDispatcher):
+    def __init__(self, sender: "FrontEndWebSockets", receiver: "FrontEndMessagesDispatcher"):
         self.sender = sender
         self.receiver = receiver
 
@@ -76,64 +81,19 @@ class WebFrontend(FrontEnd):
         return self.receiver
 
 
-class WebpageTransferEvents(TransferEvents):
-    def __init__(self, web_frontend: WebFrontend):
-        self.web_frontend = web_frontend
+class WebUserPrompts:
+    def __init__(self, frontend: WebFrontend):
+        self.frontend = frontend
 
-    async def transfer_started(self, transfer: AbstractTransferHandle):
-        pass
-
-    async def transfer_update(self, transfer_handle: AbstractTransferHandle):
-        # TODO: use `TransferStatusChanged` and `TransferUpdate` from ui_events for all of the below methods
-        status_update = DataWeaver(
-            header=headers.TRANSFER_UPDATE,
-            content={
-                'item_path': str(transfer_handle.current_transfer.path),
-                'progress': transfer_handle.status_updater.current_status,
-                'transfer_id': transfer_handle.id,
-            },
-            peer_id=transfer_handle.peer.peer_id,
+    async def ask_discovery_peer_name(self, reason: str | None) -> str | None:
+        reply = await self.frontend.send_prompt_and_get_response(
+            DiscoveryPeerNameRequested(use.get_unique_id(str), reason),
+            ProvideDiscoveryPeerName,
         )
-        self.web_frontend.send_data_to_frontend(status_update)
+        return reply.peer_name
 
-    async def transfer_completed(self, transfer: AbstractTransferHandle):
-        pass
-
-    async def transfer_incomplete(self, transfer_handle: AbstractTransferHandle, error):
-        content = {
-            'transfer_id': transfer_handle.id,
-            'cancelled': True,
-        }
-        if transfer_handle.current_transfer is not None:
-            content.update(
-                {
-                    'item_path': str(transfer_handle.current_transfer.path),
-                    'progress': transfer_handle.status_updater.current_status,
-                })
-
-        content.update({'error': str(error)} if error else {})
-
-        status_update = DataWeaver(
-            header=headers.TRANSFER_UPDATE,
-            content=content,
-            peer_id=transfer_handle.peer.peer_id,
-        )
-        self.web_frontend.send_data_to_frontend(status_update)
-
-    async def transfer_confirmation(self, transfer_handle: AbstractTransferHandle, confirmation_details):
-        dw = DataWeaver(
-            header=headers.TRANSFER_UPDATE,
-            content={"confirmation": confirmation_details, 'transferId': transfer_handle.id},
-            peer_id=transfer_handle.peer.peer_id,
-        )
-        self.web_frontend.send_data_to_frontend(dw)
-
-
-def ask_user_for_transfer_consent(frontend):
-    async def _ask_user_for_transfer_consent(peer_id: str):
-        confirmation = await frontend.send_prompt_and_get_response(
+    async def ask_transfer_consent(self, peer_id: str) -> tuple[bool, bool | None]:
+        confirmation = await self.frontend.send_prompt_and_get_response(
             IncomingTransferDecisionRequested(use.get_unique_id(str), peer_id), DecideIncomingTransfer
         )
-        return confirmation.confirmed, bool(confirmation.remember)
-
-    return _ask_user_for_transfer_consent
+        return confirmation.confirmed, confirmation.remember

--- a/src/conduit/pagehandle.py
+++ b/src/conduit/pagehandle.py
@@ -22,7 +22,7 @@ from conduit.handleprofiles import align_profiles, set_selected_profile
 from src.avails import const, use
 from src.avails.exceptions import InvalidPacket, TransferIncomplete
 from src.avails.mixins import Dispatcher
-from src.conduit.app_event_subs import sub_to_remote_peer_updates
+from src.conduit.app_event_subs import sub_to_remote_peer_updates, sub_to_transfer_updates
 from src.conduit.ui_codec import DataWeaver
 from src.configurations.appconfig import AppConfig, AppRunTime
 from websockets import ConnectionClosedError, WebSocketServerProtocol
@@ -316,6 +316,7 @@ async def subscribe_to_app_events(
 ):
     await exit_stack.enter_async_context(tg := TaskGroup())
     sub_to_remote_peer_updates(app_events, frontend, tg)
+    sub_to_transfer_updates(app_events, frontend, tg)
 
 
 async def init_page_servers(app_config, app_runtime: AppRunTime):

--- a/src/conduit/ui_events.py
+++ b/src/conduit/ui_events.py
@@ -39,6 +39,7 @@ class TransferUpdate:
     progress: int | float | None = None
     confirmation: bool | None = None
     cancelled: bool = False
+    completed: bool = False
     error: str | None = None
 
 

--- a/src/core/app_events.py
+++ b/src/core/app_events.py
@@ -17,6 +17,11 @@ _logger = logging.getLogger(__name__)
 
 __all__ = (
     "PeerStatusUpdate",
+    "TransferStarted",
+    "TransferProgressUpdated",
+    "TransferCompleted",
+    "TransferIncomplete",
+    "TransferConfirmation",
     "AppEventsBus",
     "create_app_events_bus",
 )
@@ -25,6 +30,43 @@ __all__ = (
 @dataclass(frozen=True, slots=True)
 class PeerStatusUpdate(AppEventBase):
     remote_peer: "RemotePeer"
+
+
+@dataclass(frozen=True, slots=True)
+class TransferStarted(AppEventBase):
+    transfer_id: str
+    peer_id: str
+    kind: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TransferProgressUpdated(AppEventBase):
+    transfer_id: str
+    peer_id: str
+    item_path: str | None
+    progress: int | float
+
+
+@dataclass(frozen=True, slots=True)
+class TransferCompleted(AppEventBase):
+    transfer_id: str
+    peer_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class TransferIncomplete(AppEventBase):
+    transfer_id: str
+    peer_id: str
+    item_path: str | None
+    progress: int | float | None
+    error: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class TransferConfirmation(AppEventBase):
+    transfer_id: str
+    peer_id: str
+    confirmed: bool
 
 
 class AppEventsBus:

--- a/src/core/discover.py
+++ b/src/core/discover.py
@@ -35,14 +35,12 @@ Discovery State Machine
 
 import asyncio
 import logging
-from typing import NamedTuple, TYPE_CHECKING
+from typing import NamedTuple
 
 import src.net.utils as net_util
-from src.avails import Router, WireData, const, use
-from src.avails.mixins import Dispatcher
-from src.conduit import webpage
 from src import net
-from src.conduit.ui_events import DiscoveryPeerNameRequested
+from src.avails import Router, WireData, const, use
+from src.core.user_prompts import UserPrompts
 from src.transfers import DISCOVERY
 
 _logger = logging.getLogger(__name__)
@@ -57,6 +55,7 @@ async def discovery_initiate(
         in_network,
         finalizing_event,
         transport,
+        user_prompts: UserPrompts,
 ):
     """Initializes discovery dispatcher and transport; registers handlers; sends multicast requests"""
     discovery_router = Router()
@@ -81,7 +80,8 @@ async def discovery_initiate(
             in_network,
             finalizing_event,
             discovery_transport,
-            this_remote_peer
+            this_remote_peer,
+            user_prompts,
         )
     )
     return DiscoveryService(discovery_transport, discovery_router)
@@ -128,7 +128,8 @@ async def send_discovery_requests(multicast_addr,
                                   in_network,
                                   finalizing,
                                   transport,
-                                  this_remote_peer):
+                                  this_remote_peer,
+                                  user_prompts: UserPrompts):
     """Sends multicast discovery requests with timeouts and passive fallback; queries user for peer name if unbootstrapped"""
 
     ping_data = bytes(
@@ -171,18 +172,16 @@ async def send_discovery_requests(multicast_addr,
     # try requesting user a host name of peer that is already in network
     if not kad_server.is_bootstrapped:
         _logger.debug(f"requesting user for peer name after waiting for {const.DISCOVER_TIMEOUT}s")
-        # TODO: Improve on this
-        await _try_asking_user(transport, ping_data)
+        await _try_asking_user(transport, ping_data, user_prompts)
 
     if not task.done():
         await task
 
 
-async def _try_asking_user(transport, discovery_packet):
+async def _try_asking_user(transport, discovery_packet, user_prompts: UserPrompts):
     reason = None
     while True:
-        # webpage.send_prompt_and_get_response(DiscoveryPeerNameRequested())
-        if peer_name := await webpage.ask_user_peer_name_for_discovery(reason):
+        if peer_name := await user_prompts.ask_discovery_peer_name(reason):
             try:
                 async for family, sock_type, proto, _, addr in net_util.get_addr_info(
                         peer_name,

--- a/src/core/requests.py
+++ b/src/core/requests.py
@@ -10,6 +10,7 @@ from src.configurations.appconfig import AppConfig, AppRunTime
 from src.core import _kademlia
 from src.gossip import app_gossip
 from src.core.discover import discovery_initiate
+from src.core.user_prompts import UserPrompts
 from src.net import requests
 
 _logger = logging.getLogger(__name__)
@@ -78,6 +79,7 @@ async def initiate(
       peer_service,
       app_runtime: AppRunTime,
       app_config: AppConfig,
+      user_prompts: UserPrompts,
 ):
     """
     Initializes the networking and peer-to-peer communication components
@@ -148,6 +150,7 @@ async def initiate(
         app_runtime.in_network,
         app_runtime.finalizing,
         dgram_transport,
+        user_prompts,
     )
 
     # this task is internally managed by KademliaServer

--- a/src/core/user_prompts.py
+++ b/src/core/user_prompts.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class UserPrompts(Protocol):
+    async def ask_discovery_peer_name(self, reason: str | None) -> str | None:
+        """Ask the user for a peer host/name to help discovery."""
+
+    async def ask_transfer_consent(self, peer_id: str) -> tuple[bool, bool | None]:
+        """Ask whether an incoming transfer from peer_id should be accepted.
+
+        Returns:
+            tuple of (confirmed, remember_choice)
+        """

--- a/src/managers/transfers.py
+++ b/src/managers/transfers.py
@@ -20,6 +20,8 @@ from src.avails.exceptions import (
     TransferIncomplete,
     TransferRejected,
 )
+from src.core import app_events
+from src.core.user_prompts import UserPrompts
 from src.managers import ProfileManager
 from src.managers.connection import ConnectionManager
 from src.net.events import ConnectionContext, ConnectionEvent
@@ -44,16 +46,16 @@ def init_transfer_manager(
       this_peer: RemotePeer,
       current_profile: ProfileManager,
       connection_manager: ConnectionManager,
-      ask_user: TransferConsent.TransferConsentPrompt,
-      transfer_events: TransferEvents,
+      user_prompts: UserPrompts,
+      app_event_bus: app_events.AppEventsBus,
 ) -> TransferManager:
-    transfer_consent = TransferConsent(current_profile, ask_user)
+    transfer_consent = TransferConsent(current_profile, user_prompts)
     tm = TransferManager(
         this_peer_id=this_peer.peer_id,
         connection_manager=connection_manager,
         default_download_path=const.PATH_DOWNLOAD,
         transfer_consenter=transfer_consent,
-        transfer_events=transfer_events,
+        transfer_events=AppEventTransferEvents(app_event_bus),
     )
 
     return tm
@@ -72,24 +74,22 @@ class TransferConsent:
         * waits for the receiving peer's one-byte confirmation response
         * raises ``TransferRejected`` on rejection, timeout, or invalid response
     """
-    TransferConsentPrompt = Callable[[str], Awaitable[tuple[bool, bool]]]
-
     def __init__(
           self,
-          current_profile,
-          ask_user: TransferConsentPrompt,
+          current_profile: ProfileManager,
+          user_prompts: UserPrompts,
           *,
           timeout=const.DEFAULT_TRANSFER_TIMEOUT,
     ):
         self.current_profile = current_profile
-        self.ask_user = ask_user
+        self.user_prompts = user_prompts
         self.timeout = timeout
 
     async def confirm_receiving(self, peer_id: str) -> bool:
         if (agreed := self._remembered_choice(peer_id)) is not None:
             return bool(agreed)
 
-        confirmed, remember = await self.ask_user(peer_id)
+        confirmed, remember = await self.user_prompts.ask_transfer_consent(peer_id)
 
         if remember is not None:
             await self.current_profile.add_transfers_agreed(peer_id, remember)
@@ -118,6 +118,68 @@ class TransferConsent:
 
     def _remembered_choice(self, peer_id: str):
         return getattr(self.current_profile, "transfers_agreed", {}).get(peer_id, None)
+
+
+class AppEventTransferEvents(TransferEvents):
+    def __init__(self, app_event_bus: app_events.AppEventsBus):
+        self.app_event_bus = app_event_bus
+
+    async def transfer_started(self, transfer: AbstractTransferHandle):
+        self.app_event_bus.publish(
+            app_events.TransferStarted(
+                transfer_id=str(transfer.id),
+                peer_id=transfer.peer.peer_id,
+                kind=self._transfer_kind(transfer),
+            )
+        )
+
+    async def transfer_update(self, transfer: AbstractTransferHandle):
+        self.app_event_bus.publish(
+            app_events.TransferProgressUpdated(
+                transfer_id=str(transfer.id),
+                peer_id=transfer.peer.peer_id,
+                item_path=self._current_item_path(transfer),
+                progress=transfer.status_updater.current_status,
+            )
+        )
+
+    async def transfer_completed(self, transfer: AbstractTransferHandle):
+        self.app_event_bus.publish(
+            app_events.TransferCompleted(
+                transfer_id=str(transfer.id),
+                peer_id=transfer.peer.peer_id,
+            )
+        )
+
+    async def transfer_incomplete(self, transfer: AbstractTransferHandle, error):
+        self.app_event_bus.publish(
+            app_events.TransferIncomplete(
+                transfer_id=str(transfer.id),
+                peer_id=transfer.peer.peer_id,
+                item_path=self._current_item_path(transfer),
+                progress=transfer.status_updater.current_status,
+                error=str(error) if error else None,
+            )
+        )
+
+    async def transfer_confirmation(self, transfer: AbstractTransferHandle, confirmation_details):
+        self.app_event_bus.publish(
+            app_events.TransferConfirmation(
+                transfer_id=str(transfer.id),
+                peer_id=transfer.peer.peer_id,
+                confirmed=bool(confirmation_details),
+            )
+        )
+
+    @staticmethod
+    def _current_item_path(transfer: AbstractTransferHandle):
+        current = transfer.current_transfer
+        return str(current.path) if current is not None else None
+
+    @staticmethod
+    def _transfer_kind(transfer: AbstractTransferHandle):
+        record = getattr(transfer, "kind", None)
+        return getattr(record, "value", record)
 
 
 class TransferManager:
@@ -173,6 +235,7 @@ class TransferManager:
             async with self._sender_connection(sender, HEADERS.CMD_FILE_CONN) as connection:
                 await self._run_transfer(status_updater, sender, connection)
         except TransferRejected as exp:
+            await self.transfer_events.transfer_confirmation(sender, False)
             await self.transfer_events.transfer_incomplete(sender, exp)
             raise
         finally:
@@ -203,6 +266,7 @@ class TransferManager:
             ) as connection:
                 await self._run_transfer(status_updater, sender, connection)
         except TransferRejected as exp:
+            await self.transfer_events.transfer_confirmation(sender, False)
             await self.transfer_events.transfer_incomplete(sender, exp)
             raise
         finally:
@@ -239,6 +303,7 @@ class TransferManager:
                 await self._run_transfer(status_iterator, sender, connection1)
 
         except TransferRejected as exp:
+            await self.transfer_events.transfer_confirmation(sender, False)
             await self.transfer_events.transfer_incomplete(sender, exp)
             raise
         finally:
@@ -506,6 +571,7 @@ class TransferManager:
           transfer_handle: AbstractTransferHandle,
           *connections,
     ):
+        await self.transfer_events.transfer_started(transfer_handle)
         async with transfer_handle, aclosing(transfer_handle.start_transfer()) as loop:
             for connection in connections:
                 transfer_handle.connection_made(connection)
@@ -568,5 +634,7 @@ class TransferManager:
 
         if transfer_handle.state in (TransferState.COMPLETED, TransferState.ABORTING):
             self.transfers_book.move(transfer_handle.id, TransferBookBucket.COMPLETED)
+            if transfer_handle.state is TransferState.COMPLETED:
+                await self.transfer_events.transfer_completed(transfer_handle)
         elif transfer_handle.state in (TransferState.PAUSED, TransferState.CONNECTING):
             self.transfers_book.move(transfer_handle.id, TransferBookBucket.SCHEDULED)


### PR DESCRIPTION
refactor: now transfer updates are sent through app event and ui layers subscribes to transfer events forwarding them to frontend

* new abstraction `UserPrompts`, this is used by application code for user inputs (at this point, discovery and transfer consent uses this)
